### PR TITLE
Output startup errors

### DIFF
--- a/src/IISExpressBootstrapper.AcceptanceTests/IISExpressHostTests.cs
+++ b/src/IISExpressBootstrapper.AcceptanceTests/IISExpressHostTests.cs
@@ -83,5 +83,16 @@ namespace IISExpressBootstrapper.AcceptanceTests
             action.ShouldThrow<DirectoryNotFoundException>()
                 .WithMessage("Could not infer the web application folder path.");
         }
+
+        [Test]
+        public void StartingWithInvalidConfigurationShouldWriteMessage()
+        {
+            string s = null;
+
+            IISExpressHost.Start(new ConfigFileParameters { ConfigFile = "", SiteName = "Does not exist" },
+                output: message => { s = message; });
+
+            s.Should().NotBeNullOrEmpty();
+        }
     }
 }

--- a/src/IISExpressBootstrapper/Configuration.cs
+++ b/src/IISExpressBootstrapper/Configuration.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace IISExpressBootstrapper
 {
@@ -9,5 +10,7 @@ namespace IISExpressBootstrapper
         public Parameters ProcessParameters { get; set; }
 
         public IDictionary<string, string> EnvironmentVariables { get; set; }
+
+        public Action<string> Output { get; set; }
     }
 }

--- a/src/IISExpressBootstrapper/IISExpressHost.cs
+++ b/src/IISExpressBootstrapper/IISExpressHost.cs
@@ -6,21 +6,21 @@ namespace IISExpressBootstrapper
     public class IISExpressHost : IDisposable
     {
         public static IISExpressHost Start(string webApplicationName, int portNumber,
-            IDictionary<string, string> environmentVariables = null, string iisExpressPath = null)
+            IDictionary<string, string> environmentVariables = null, string iisExpressPath = null, Action<string> output = null)
         {
-            return new IISExpressHost(webApplicationName, portNumber, environmentVariables, iisExpressPath);
+            return new IISExpressHost(webApplicationName, portNumber, environmentVariables, iisExpressPath, output);
         }
 
         public static IISExpressHost Start(Parameters parameters, IDictionary<string, string> environmentVariables = null,
-            string iisExpressPath = null)
+            string iisExpressPath = null, Action<string> output = null)
         {
-            return new IISExpressHost(parameters, environmentVariables, iisExpressPath);
+            return new IISExpressHost(parameters, environmentVariables, iisExpressPath, output);
         }
 
         private IISExpressProcess process;
 
         public IISExpressHost(string webApplicationName, int portNumber,
-            IDictionary<string, string> environmentVariables = null, string iisExpressPath = null)
+            IDictionary<string, string> environmentVariables = null, string iisExpressPath = null, Action<string> output = null)
         {
             var configuration = new Configuration
             {
@@ -31,20 +31,22 @@ namespace IISExpressBootstrapper
                     Path = Locator.GetFullPath(webApplicationName),
                     Port = portNumber,
                     Systray = false
-                }
+                },
+                Output = output
             };
 
             process = new IISExpressProcess(configuration);
         }
 
         private IISExpressHost(Parameters parameters, IDictionary<string, string> environmentVariables = null,
-            string iisExpressPath = null)
+            string iisExpressPath = null, Action<string> output = null)
         {
             var configuration = new Configuration
             {
                 EnvironmentVariables = environmentVariables,
                 IISExpressPath = iisExpressPath,
-                ProcessParameters = parameters
+                ProcessParameters = parameters,
+                Output = output
             };
             process = new IISExpressProcess(configuration);
         }

--- a/src/IISExpressBootstrapper/IISExpressProcess.cs
+++ b/src/IISExpressBootstrapper/IISExpressProcess.cs
@@ -18,7 +18,8 @@ namespace IISExpressBootstrapper
                 throw new IISExpressNotFoundException();
             }
 
-            process = ProcessRunner.Run(configuration.IISExpressPath, configuration.ProcessParameters.ToString(), configuration.EnvironmentVariables);
+            process = ProcessRunner.Run(configuration.IISExpressPath, configuration.ProcessParameters.ToString(), configuration.EnvironmentVariables, 
+                configuration.Output);
         }
 
         public void Dispose()


### PR DESCRIPTION
Occasionally tests in my own projects, which consume this library, fail and I don't know why because there is no log, so I've added a way to get the output from the process on startup.